### PR TITLE
add own footer and links to posting on social media

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,45 @@
+<footer class="site-footer h-card">
+  <data class="u-url" href="{{ "/" | relative_url }}"></data>
+
+  <div class="wrapper">
+
+    <div class="footer-col-wrapper">
+      <div class="footer-col">
+        <p class="feed-subscribe">
+          <a href="{{ site.feed.path | default: 'feed.xml' | absolute_url }}">
+            <svg class="svg-icon orange">
+              <use xlink:href="{{ 'assets/minima-social-icons.svg#rss' | relative_url }}"></use>
+            </svg><span>Subscribe</span>
+          </a>
+        </p>
+      {%- if site.author %}
+        <ul class="contact-list">
+          {% if site.author.name -%}
+            <li class="p-name">{{ site.author.name | escape }}</li>
+          {% endif -%}
+          {% if site.author.email -%}
+            <li><a class="u-email" href="mailto:{{ site.author.email }}">{{ site.author.email }}</a></li>
+          {%- endif %}
+        </ul>
+      {%- endif %}
+      </div>
+      <div class="footer-col">
+        <p>{{ site.description | escape }}</p>
+      </div>
+    </div>
+
+<!-- AddToAny BEGIN -->
+<div class="a2a_kit a2a_kit_size_32 a2a_default_style">
+<a class="a2a_dd" href="https://www.addtoany.com/share"></a>
+<a class="a2a_button_facebook"></a>
+<a class="a2a_button_mastodon"></a>
+<a class="a2a_button_email"></a>
+<a class="a2a_button_bluesky"></a>
+<a class="a2a_button_x"></a>
+</div>
+<script defer src="https://static.addtoany.com/menu/page.js"></script>
+<!-- AddToAny END -->
+
+  </div>
+
+</footer>


### PR DESCRIPTION
Add our own footer based on tips found here: https://stackoverflow.com/questions/60231233/editing-the-footer-in-github-pages-jekylls-default-minima-theme
Add to this footer buttons from https://www.addtoany.com/.

Hard for me to test of course but seems to create a post based on the title of the page and link to this page. Some things (like Mastadon) seem to have the actual content of the page posted. Example of what this looks like below. 

ok @neilflood @petescarth?

![image](https://github.com/user-attachments/assets/b566b8d4-50a2-4ba4-950e-9672d3a3b649)
